### PR TITLE
support blogc-make as build tool.

### DIFF
--- a/blogcfile
+++ b/blogcfile
@@ -1,0 +1,30 @@
+[environment]
+AUTHOR_NAME = "Shiba"
+AUTHOR_EMAIL = "example@email.com"
+SITE_TITLE = "Lanyon"
+SITE_TAGLINE = "Now for blogc too!"
+SITE_DESCRIPTION = "A reserved <a href=\"http://jekyllrb.com\" target=\"_blank\">Jekyll</a> theme that places the utmost gravity on content with a hidden drawer. Made by <a href=\"https://twitter.com/mdo\" target=\"_blank\">@mdo</a>.<br>Ported to <a href=\"http://blogc.org/\">blogc</a> by Shiba."
+BASE_DOMAIN = "http://example.com"
+
+[settings]
+locale = "en_US.utf-8"
+date_format = "%d %b %Y"
+posts_per_page = 5
+atom_posts_per_page = 10
+source_ext = .md
+
+[posts]
+2014-01-02-introducing-lanyon
+2014-01-01-example-content
+2013-12-31-whats-jekyll
+
+[pages]
+about
+404
+
+[copy_files]
+assets/css/poole.css
+assets/css/syntax.css
+assets/css/lanyon.css
+assets/apple-touch-icon-precomposed.png
+assets/favicon.ico

--- a/templates/main.tmpl
+++ b/templates/main.tmpl
@@ -42,9 +42,9 @@ vim: et ts=2 sts=2 sw=2:
 
       <nav class="sidebar-nav">
       <!-- Home link -->
-      <a class="sidebar-nav-item{%if MENU == "blog" %} active{% endif %}" href="{{ BASE_URL }}/">Home</a>
+      <a class="sidebar-nav-item{%if MENU == "blog" %} active{% endif %}{% if BM_TYPE == "post" %} active{% endif %}" href="{{ BASE_URL }}/">Home</a>
       <!-- About link -->
-      <a class="sidebar-nav-item{%if MENU == "about" %} active{% endif %}" href="{{ BASE_URL }}/about/">About</a>
+      <a class="sidebar-nav-item{%if MENU == "about" %} active{% endif %}{% if BM_TYPE == "page" %}{% if FILENAME == "about" %} active{% endif %}{% endif %}" href="{{ BASE_URL }}/about/">About</a>
 
       <a class="sidebar-nav-item" href="https://github.com/shiba89/lanyon-blogc/archive/master.zip">Download</a>
       <a class="sidebar-nav-item" href="https://github.com/shiba89/lanyon-blogc">GitHub project</a>


### PR DESCRIPTION
blogc-make is a built tool that replaces make and implements all the
rules needed to build a blogc website. the blogcfile added here covers
all the features previously implemented in the makefile, but the
'reload' task was not implemented in blogc-make yet.

WARNING: blogc-make is still experimental, no stable release includes it
yet! The blogcfile syntax may change!